### PR TITLE
fix(updates): fix issue with single window tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A browser extension to prevent unintended closing of an open window when the last tab in the window is closed mistakenly
 
-- [Extension on Google Chrome Store](https://chrome.google.com/webstore/detail/whave/onmmaefeecidiliagmmbelkaeicmaang?utm_source=chrome-ntp-icon)
+- [Extension on Google Chrome Store](https://chromewebstore.google.com/detail/before-closing-the-last-t/njncdcmlohakjhpcdbimfhndgkahlgfi?utm_source=chrome-ntp-icon)
 
 ## Why
 

--- a/b4xw.js
+++ b/b4xw.js
@@ -6,15 +6,21 @@ const beforeUnload = (event) => {
   return ""
 }
 
-window.addEventListener("focus", function () {
+function checkTabCountAndSetUnload() {
   const port = chrome.runtime.connect({ name: "contentScriptConnection" })
   port.postMessage({ message: "Registering tab with background script" })
   port.onMessage.addListener(function ({ tabsLength }) {
-    if (tabsLength == 1) {
+    if (tabsLength === 1) {
       console.log(`Adding unload event to last tab ${tabsLength}`)
       window.addEventListener("beforeunload", beforeUnload)
     } else {
       window.removeEventListener("beforeunload", beforeUnload)
     }
   })
-})
+}
+
+// Check tab count on load
+checkTabCountAndSetUnload()
+
+// Check tab count on focus
+window.addEventListener("focus", checkTabCountAndSetUnload)


### PR DESCRIPTION
The focus event is skipped on page load, which prevents us from adding the warning on single tab windows. 
This calls the event from when the script is loaded